### PR TITLE
Ignore .imported torrents

### DIFF
--- a/lib/yamazaki/yamazaki.rb
+++ b/lib/yamazaki/yamazaki.rb
@@ -42,7 +42,7 @@ module Yamazaki
 			watch_dir = defined?(WATCH_DIR) == 'constant' ? WATCH_DIR : DEFAULT_WATCH_DIR
 			filename = "#{watch_dir}/#{name}.torrent"
 
-			if force != true && File.exists?(filename)
+			if force != true && (File.exists?(filename) || File.exists?("#{filename}.imported"))
 				false
 			else
 				File.open(filename, ?w) { |torrent_file| torrent_file.write(open(link).read) }


### PR DESCRIPTION
Clients like uTorrent rename the torrents put in download queue in `$filename.imported`.
This patch lets yamazaki to ignore them.